### PR TITLE
Fix error: form control with name='...' is not focusable

### DIFF
--- a/assets/javascripts/ldap_settings.js
+++ b/assets/javascripts/ldap_settings.js
@@ -23,11 +23,21 @@ $(function() {
     var selected = $(elem).val();
     var prefix = '#ldap_attributes div.' + ambit;
 
+    $(prefix).hide();
+
+    // Remove required for hidden elements
+    $(prefix + ' input').removeAttr('required');
+
     if (selected !== '') {
       $(prefix + '.' + selected).show();
-      $(prefix + ':not(.' + selected + ')').hide();
-    } else {
-      $(prefix).hide();
+      
+      // Add required for visible and required inputs
+      $(prefix + '.' + selected + ' input').each(function(){
+
+        if($('label[for="' + this.id + '"]').hasClass('required'))
+          $(this).attr('required', 'required');
+
+      });
     }
   }
 


### PR DESCRIPTION
### Current Behavior
Clicking "Save" button in plugin settings does not submit the form. The following error is thrown (in Chrome):

```
An invalid form control with name='ldap_setting[parent_group]' is not focusable.
An invalid form control with name='ldap_setting[group_parentid]' is not focusable.
An invalid form control with name='ldap_setting[member_group]' is not focusable.
An invalid form control with name='ldap_setting[group_memberid]' is not focusable.
```

### Solution

Error is thrown because there are hidden required inputs. To solve this, `required` attribute must be removed when inputs are hidden and added when they are shown again.

### Tests
This PR has been tested in the following browsers:
* Google Chrome 80
* Firefox 74

Redmine version: `4.1.0.stable` with Easy Redmine `9.00 (ER 2019)`