### PR TITLE
Fix issue 3: ActionController::Parameters no longer inherits from HashWithIndifferentAccess in rails 5

### DIFF
--- a/app/models/ldap_setting.rb
+++ b/app/models/ldap_setting.rb
@@ -179,7 +179,8 @@ class LdapSetting
   def user_field(ldap_attr)
     ldap_attr = ldap_attr.to_s
     result = @user_standard_ldap_attrs.find {|(k, v)| v.downcase == ldap_attr }.try(:first)
-    result ||= user_ldap_attrs.find {|(k, v)| v.downcase == ldap_attr }.try(:first)
+    user_ldap_attrs.permit!
+    result ||= user_ldap_attrs.to_h.find {|(k, v)| v.downcase == ldap_attr }.try(:first)
   end
 
   def test


### PR DESCRIPTION
ActionController::Parameters no longer inherits from HashWithIndifferentAccess in rails 5

See here https://bigbinary.com/blog/parameters-no-longer-inherit-from-hash-with-indifferent-access-in-rails-5

I am permitting all the attributes inside the user_ldap_attrs variable before transforming it into a hash. Then it is compatible with the find method and all the rest should work as it was.

Regards