### PR TITLE
Fix error: form control with name='ldap_setting[dyngroups_cache_ttl]'…

### DIFF
--- a/app/views/ldap_settings/_synchronization_actions.html.erb
+++ b/app/views/ldap_settings/_synchronization_actions.html.erb
@@ -8,7 +8,7 @@
   <p><%= f.check_box :create_users %></p>
   <p><%= f.check_box :create_groups %></p>
   <p><%= f.select :dyngroups, options_for_dyngroups %>
-    <span id="dyngroups-cache-ttl"><%= f.text_field :dyngroups_cache_ttl, :required => true, :size => 5 %> <%= l(:label_minutes) %></span>
+    <span id="dyngroups-cache-ttl"><%= f.text_field :dyngroups_cache_ttl, :size => 5 %> <%= l(:label_minutes) %></span>
   </p>
   <div class="paragraph">
     <label><%= l(:field_user_group_fields) %></label>

--- a/assets/javascripts/ldap_settings.js
+++ b/assets/javascripts/ldap_settings.js
@@ -42,10 +42,15 @@ $(function() {
   }
 
   function show_dyngroups_ttl(elem) {
-    if ($(elem).val() == 'enabled_with_ttl')
+    if ($(elem).val() == 'enabled_with_ttl') {
       $('#dyngroups-cache-ttl').show();
-    else
+      $('[name="ldap_setting[dyngroups_cache_ttl]"]').attr('required','required');
+      $('[for="ldap_setting_dyngroups_cache_ttl"]').addClass('required').append("<span class='required'>*</span>");
+    } else {
       $('#dyngroups-cache-ttl').hide();
+      $('[name="ldap_setting[dyngroups_cache_ttl]"]').removeAttr('required');
+      $('[for="ldap_setting_dyngroups_cache_ttl"] > span').remove();
+    }
   }
 
   show_options($('#ldap_setting_group_membership'), 'membership');


### PR DESCRIPTION
# Current Behavior
Clicking "Save" button in plugin settings does not submit the form. The following error is thrown (in Chrome):

`An invalid form control with name='ldap_setting[dyngroups_cache_ttl]' is not focusable.`
# Solution
Error is thrown because there are hidden required input. To solve this, required attribute must be removed when inputs are hidden and added when they are shown again.

# Tests
This PR has been tested in the following browsers:

* Google Chrome 90
* Firefox 88

Redmine version: 4.1.1.stable with Easy Redmine 10.10.2